### PR TITLE
Remove redundant argocd-hook

### DIFF
--- a/garage/templates/job-configure.yaml
+++ b/garage/templates/job-configure.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-    "argocd.argoproj.io/hook": PostSync
+    "argocd.argoproj.io/hook": Sync
     "argocd.argoproj.io/hook-delete-policy": BeforeHookCreation,HookSucceeded
 spec:
   template:


### PR DESCRIPTION
#### Please check if the PR fulfills these requirements
- [ x ] The branch naming convention follows our guidelines
- [ ~ no logic update ] Docs have been added / updated (for bug fixes / features)

#### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

It removes a redundant argocd-annotation that makes the configuration-job only start on "postSync", so when the whole deployment is synced successfully. This resolves a circular dependency problem. When some other k8s-deployments require garage for their own syncing process and try to connect (for init-migrations for example), they fail, argocd does not successfully sync and the init-container never starts which results in a chicken and egg situation. garage waits for sync-finished to initialize and be reachable ; the other service waits/restarts until garage is reachable and blocks argocd-sync state (PostSync-hook never triggers).
The waiting for garage-initialized is already done in the init-script, which makes the PostSync hook redundant. Removing the argocd-hook will as a result init garage to happen while the other service is still waiting, garage starts-up independent of other services and will be reachable when other services might still be syncing.
(The other change: add publishNotReadyAddresses to the headless-service so that the script can reach unititialized garage)

#### What is the current behavior? (You can also link to an open issue here)

Garage waits until itself and all other services are synced and ready before initializing via a script.

#### What is the new behavior (if this is a feature change)?

Garage does not wait for synced state (of other services *and* itself), but because the init-config-script waits for open connection, the waiting happens here. Garage can thus start up independently of the whole argocd-deployment state, which allows other services to connect to it and communicate during their startup-phase.

#### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No, this only reorders the startup-structure and makes garage available a bit faster than when argocd is synced.

#### Other information:

-

<!-- By submitting this Pull Request, you agree to follow our [Code of Conduct](https://github.com/datahub-local/garage-helm/CONTRIBUTING.md) -->
