### PR TITLE
Add annotation for startup-init-reachability

### DIFF
--- a/garage/templates/service-headless.yaml
+++ b/garage/templates/service-headless.yaml
@@ -8,6 +8,7 @@ metadata:
 spec:
   type: ClusterIP
   clusterIP: None
+  publishNotReadyAddresses: true
   ports:
     - port: {{ .Values.service.ports.s3Api }}
       targetPort: s3-api

--- a/garage/tests/job-configure_test.yaml
+++ b/garage/tests/job-configure_test.yaml
@@ -37,7 +37,7 @@ tests:
     asserts:
       - equal:
           path: metadata.annotations["argocd.argoproj.io/hook"]
-          value: PostSync
+          value: Sync
       - equal:
           path: metadata.annotations["argocd.argoproj.io/hook-delete-policy"]
           value: BeforeHookCreation,HookSucceeded

--- a/garage/tests/service-headless_test.yaml
+++ b/garage/tests/service-headless_test.yaml
@@ -26,6 +26,12 @@ tests:
       - equal:
           path: spec.clusterIP
           value: None
+  
+  - it: should publish not-ready addresses for early-init
+    asserts:
+      - equal:
+          path: spec.publishNotReadyAddresses
+          value: true
 
   # Port configuration tests
   - it: should expose all required ports


### PR DESCRIPTION
…lity

#### Please check if the PR fulfills these requirements
- [ x ] The branch naming convention follows our guidelines
- [ ~ not necessary] Docs have been added / updated (for bug fixes / features)

#### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

The second annotation for the headless-svc mentioned in the previous fix (more graceful garage-startup), which I was not able to add before the PR was accepted :). Only with this annotation can the script reach the pod for init. By default svc only forward requests, when the pod is healthy, because probes can be set, the probes fail until config-init is done, which the script tries to do.

Added/Fixed tests

#### What is the current behavior? (You can also link to an open issue here)

The pod/container is not reachable before successful config-init.

#### What is the new behavior (if this is a feature change)?

The script can resolve ip-address and reach the container.

#### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

no, only modifies svc ip-resolution to start earlier (before the pod is healthy)

#### Other information:

-

<!-- By submitting this Pull Request, you agree to follow our [Code of Conduct](https://github.com/datahub-local/garage-helm/CONTRIBUTING.md) -->
