### PR TITLE
Add support for the webui base path env variable

### DIFF
--- a/garage/README.md
+++ b/garage/README.md
@@ -144,6 +144,7 @@ S3-compatible object store for small self-hosted geo-distributed deployments.
 | webui.auth.enabled | bool | `false` | Enable authentication for WebUI |
 | webui.auth.existingSecret | string | `""` | Use an existing secret for authentication (must contain 'webuiAuthUserPass' key) |
 | webui.auth.userPassHash | string | `""` | When the chart manages the auth secret, provide this together with garage.secret.rpcSecret and garage.secret.adminToken. Generate with: htpasswd -nbBC 10 "username" "password" Example: "admin:$2y$10$DSTi9o..." |
+| webui.basePath | string | `"/"` | Base path or prefix for Web UI |
 | webui.enabled | bool | `false` | Enable the garage-webui deployment |
 | webui.extraVolumeMounts | object | `{}` | extra volume mounts for WebUI |
 | webui.extraVolumes | object | `{}` | extra volumes for WebUI |

--- a/garage/templates/webui-deployment.yaml
+++ b/garage/templates/webui-deployment.yaml
@@ -51,6 +51,8 @@ spec:
                   name: {{ .Values.webui.auth.existingSecret | default (include "garage.secretName" .) }}
                   key: webuiAuthUserPass
             {{- end }}
+            - name: BASE_PATH
+              value: {{ .Values.webui.basePath }}
           ports:
             - name: http
               containerPort: 3909

--- a/garage/values.yaml
+++ b/garage/values.yaml
@@ -426,6 +426,9 @@ webui:
   # -- Enable the garage-webui deployment
   enabled: false
 
+  # -- Base path or prefix for Web UI
+  basePath: "/"
+
   # -- Number of WebUI replicas
   replicaCount: 1
 


### PR DESCRIPTION
#### Please check if the PR fulfills these requirements
- [x] The branch naming convention follows our guidelines
- [x] Docs have been added / updated (for bug fixes / features)

#### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

Feature: configurable Web UI base path for the garage-webui deployment.

#### What is the current behavior? (You can also link to an open issue here)

The Web UI container is deployed without BASE_PATH. Serving the UI behind a reverse proxy under a subpath (for example /garage/) is awkward or broken unless the app defaults happen to match.

#### What is the new behavior (if this is a feature change)?

webui.basePath is added (default "/"). It is passed to the Web UI pod as the BASE_PATH environment variable so operators can align the app with their ingress path prefix.

#### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. Existing installs keep the default "/"; only deployments that need a subpath should set webui.basePath (and configure ingress accordingly).

#### Other information:

- Values: `garage/values.yaml` — webui.basePath
- Template: `garage/templates/webui-deployment.yaml` — BASE_PATH env
- Docs: `garage/README.md` — values table updated


<!-- By submitting this Pull Request, you agree to follow our [Code of Conduct](https://github.com/datahub-local/garage-helm/CONTRIBUTING.md) -->
