### PR TITLE
feat: add key permissions flags

### DIFF
--- a/garage/examples/advanced.yaml
+++ b/garage/examples/advanced.yaml
@@ -43,25 +43,42 @@ clusterConfig:
       public: true
     - name: compliance
   keys:
-    # Example of multiple keys with different bucket access within values.yaml
+    # Read-write access to specific buckets
     analytics-media-key:
       keyId: GKFEDCBA9876543210FEDCBA98
       secretKey: 89abcdef0123456789abcdef0123456789abcdef0123456789abcdef01234567
       buckets:
-        - analytics
-        - media
-    compliance-key:
+        - name: analytics
+          read: true
+          write: true
+        - name: media
+          read: true
+          write: true
+    # Read-only access
+    compliance-reader-key:
       keyId: GK00112233445566778899AABB
       secretKey: 76543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba98
       buckets:
-        - compliance
+        - name: compliance
+          read: true
+    # Owner access (can manage bucket settings)
+    compliance-owner-key:
+      keyId: GK00112233445566778899CCDD
+      secretKey: aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899
+      buckets:
+        - name: compliance
+          read: true
+          write: true
+          owner: true
     # Example using a secret created via extraResources
     external-key:
       secretName: my-external-key
       keyId: keyId
       secretKey: secretKey
       buckets:
-        - analytics
+        - name: analytics
+          read: true
+          write: true
   resources:
     requests:
       cpu: 250m

--- a/garage/templates/secret-configure.yaml
+++ b/garage/templates/secret-configure.yaml
@@ -107,7 +107,11 @@ stringData:
     run_garage key import "$KEY_ID" "$SECRET_KEY" --yes -n "{{ $name }}" || true
     {{- if $key.buckets }}
     {{- range $bucket := $key.buckets }}
+    {{- if kindIs "string" $bucket }}
     run_garage bucket allow {{ $bucket }} --key "$KEY_ID" --read --write || true
+    {{- else }}
+    run_garage bucket allow {{ $bucket.name }} --key "$KEY_ID"{{- if $bucket.read }} --read{{- end }}{{- if $bucket.write }} --write{{- end }}{{- if $bucket.owner }} --owner{{- end }} || true
+    {{- end }}
     {{- end }}
     {{- end }}
     {{- end }}

--- a/garage/tests/secret-configure_test.yaml
+++ b/garage/tests/secret-configure_test.yaml
@@ -1,0 +1,148 @@
+suite: Secret Configure tests
+templates:
+  - secret-configure.yaml
+tests:
+  - it: should not create Secret when disabled
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create Secret when enabled
+    set:
+      clusterConfig.enabled: true
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-garage-configure-script
+
+  - it: should include configure.sh script
+    set:
+      clusterConfig.enabled: true
+    asserts:
+      - exists:
+          path: stringData["configure.sh"]
+
+  # Bucket permissions - string format
+  - it: string bucket format should grant read and write
+    set:
+      clusterConfig.enabled: true
+      clusterConfig.keys:
+        my-key:
+          secretName: my-secret
+          keyId: keyId
+          secretKey: secretKey
+          buckets:
+            - my-bucket
+    asserts:
+      - matchRegex:
+          path: stringData["configure.sh"]
+          pattern: "bucket allow my-bucket --key .* --read --write"
+
+  # Bucket permissions - object format
+  - it: object bucket with read and write should grant read and write
+    set:
+      clusterConfig.enabled: true
+      clusterConfig.keys:
+        my-key:
+          secretName: my-secret
+          keyId: keyId
+          secretKey: secretKey
+          buckets:
+            - name: my-bucket
+              read: true
+              write: true
+    asserts:
+      - matchRegex:
+          path: stringData["configure.sh"]
+          pattern: "bucket allow my-bucket --key .* --read --write"
+      - notMatchRegex:
+          path: stringData["configure.sh"]
+          pattern: "--owner"
+
+  - it: object bucket with read only should not grant write
+    set:
+      clusterConfig.enabled: true
+      clusterConfig.keys:
+        my-key:
+          secretName: my-secret
+          keyId: keyId
+          secretKey: secretKey
+          buckets:
+            - name: my-bucket
+              read: true
+    asserts:
+      - matchRegex:
+          path: stringData["configure.sh"]
+          pattern: "bucket allow my-bucket --key .* --read"
+      - notMatchRegex:
+          path: stringData["configure.sh"]
+          pattern: "bucket allow my-bucket --key .* --write"
+
+  - it: object bucket with write only should not grant read
+    set:
+      clusterConfig.enabled: true
+      clusterConfig.keys:
+        my-key:
+          secretName: my-secret
+          keyId: keyId
+          secretKey: secretKey
+          buckets:
+            - name: my-bucket
+              write: true
+    asserts:
+      - matchRegex:
+          path: stringData["configure.sh"]
+          pattern: "bucket allow my-bucket --key .* --write"
+      - notMatchRegex:
+          path: stringData["configure.sh"]
+          pattern: "bucket allow my-bucket --key .* --read"
+
+  - it: object bucket with owner flag should include owner
+    set:
+      clusterConfig.enabled: true
+      clusterConfig.keys:
+        my-key:
+          secretName: my-secret
+          keyId: keyId
+          secretKey: secretKey
+          buckets:
+            - name: my-bucket
+              read: true
+              write: true
+              owner: true
+    asserts:
+      - matchRegex:
+          path: stringData["configure.sh"]
+          pattern: "bucket allow my-bucket --key .* --read --write --owner"
+
+  - it: object bucket without owner flag should not include owner
+    set:
+      clusterConfig.enabled: true
+      clusterConfig.keys:
+        my-key:
+          secretName: my-secret
+          keyId: keyId
+          secretKey: secretKey
+          buckets:
+            - name: my-bucket
+              read: true
+              write: true
+    asserts:
+      - notMatchRegex:
+          path: stringData["configure.sh"]
+          pattern: "--owner"
+
+  - it: key with no buckets should not emit bucket allow
+    set:
+      clusterConfig.enabled: true
+      clusterConfig.keys:
+        my-key:
+          secretName: my-secret
+          keyId: keyId
+          secretKey: secretKey
+    asserts:
+      - notMatchRegex:
+          path: stringData["configure.sh"]
+          pattern: "bucket allow"

--- a/garage/values.yaml
+++ b/garage/values.yaml
@@ -359,13 +359,22 @@ clusterConfig:
   # my-key:
   #   keyId: GK12345678901234567890abcd
   #   secretKey: 123456789012345678901234567890123456789012345678901234567890abcd
-  #   buckets: [] # Optional list of buckets to allow access to
+  #   buckets:
+  #     # String format - grants read+write
+  #     - my-bucket
+  #     # Object format - explicit per-bucket permissions
+  #     - name: my-other-bucket
+  #       read: true
+  #       write: true
+  #       owner: false  # optional, grants owner permissions
   # 2. Use an existing secret in kubernetes (containing the keyId and secretKey)
   # my-existing-key:
   #   secretName: someSecretWithKeys
   #   keyId: keyIdA
   #   secretKey: secretKeyA
-  #   buckets: [] # Optional list of buckets to allow access to
+  #   buckets:
+  #     - name: my-bucket
+  #       read: true  # read-only key
 
   # -- Extra commands to run
   extraCommands: []


### PR DESCRIPTION
#### Please check if the PR fulfills these requirements
- [x] The branch naming convention follows our guidelines
- [x] Docs have been added / updated (for bug fixes / features)

#### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

Allow to choose the flags used when allowing a key on a bucket: `--read`, `--write`, `--owner`

#### What is the current behavior? (You can also link to an open issue here)

https://github.com/datahub-local/garage-helm/issues/23

All keys are added with read/write permissions.

#### What is the new behavior (if this is a feature change)?

It allows to control these permissions.

#### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No, it supports the old behavior in addition of the new one. 

#### Other information:

There wasn't tests for `clusterConfig`, I added some

<!-- By submitting this Pull Request, you agree to follow our [Code of Conduct](https://github.com/datahub-local/garage-helm/CONTRIBUTING.md) -->
