### PR TITLE
Add configurability to helm-sync behaviour of job-configure

### DIFF
--- a/garage/README.md
+++ b/garage/README.md
@@ -1,6 +1,6 @@
 # garage
 
-![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.3.0](https://img.shields.io/badge/AppVersion-v2.3.0-informational?style=flat-square)
+![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.2.0](https://img.shields.io/badge/AppVersion-v2.2.0-informational?style=flat-square)
 
 S3-compatible object store for small self-hosted geo-distributed deployments.
 
@@ -24,6 +24,9 @@ S3-compatible object store for small self-hosted geo-distributed deployments.
 | affinity | object | `{}` |  |
 | clusterConfig | object | `{"affinity":{},"buckets":[],"configureImage":{"pullPolicy":"IfNotPresent","repository":"busybox","tag":"latest"},"enabled":false,"extraCommands":[],"image":{"pullPolicy":"IfNotPresent","repository":"","tag":""},"imagePullSecrets":[],"keys":{},"layout":{"capacity":"","enabled":true,"zone":"dc1"},"nodeSelector":{},"podAnnotations":{},"podSecurityContext":{"fsGroup":1000,"fsGroupChangePolicy":"OnRootMismatch","runAsGroup":1000,"runAsNonRoot":true,"runAsUser":1000},"resources":{},"securityContext":{"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true},"tolerations":[],"toolsImage":{"pullPolicy":"IfNotPresent","repository":"busybox","tag":"musl"}}` | Garage Cluster configuration |
 | clusterConfig.affinity | object | `{}` | Affinity |
+| clusterConfig.helmSync | object | `{"asHook":true,"ttlSecondsAfterFinished":300}` | Change sync behaviour with helm (helm install or helm upgrade) |
+| clusterConfig.helmSync.asHook | bool | `true` | If true, the configure job runs as a post-install/post-upgrade hook (waits for all resources to be ready first). Set to false to run the job as a regular resource alongside other pods. |
+| clusterConfig.helmSync.ttlSecondsAfterFinished | int | `300` | Time in seconds to keep the completed job before automatic cleanup (only applies when asHook is false) |
 | clusterConfig.buckets | list | `[]` | List of buckets to create |
 | clusterConfig.configureImage.repository | string | `"busybox"` | Image to use for the configure task for the configuration job |
 | clusterConfig.enabled | bool | `false` | Enable the cluster configuration job |
@@ -144,7 +147,6 @@ S3-compatible object store for small self-hosted geo-distributed deployments.
 | webui.auth.enabled | bool | `false` | Enable authentication for WebUI |
 | webui.auth.existingSecret | string | `""` | Use an existing secret for authentication (must contain 'webuiAuthUserPass' key) |
 | webui.auth.userPassHash | string | `""` | When the chart manages the auth secret, provide this together with garage.secret.rpcSecret and garage.secret.adminToken. Generate with: htpasswd -nbBC 10 "username" "password" Example: "admin:$2y$10$DSTi9o..." |
-| webui.basePath | string | `"/"` | Base path or prefix for Web UI |
 | webui.enabled | bool | `false` | Enable the garage-webui deployment |
 | webui.extraVolumeMounts | object | `{}` | extra volume mounts for WebUI |
 | webui.extraVolumes | object | `{}` | extra volumes for WebUI |

--- a/garage/README.md
+++ b/garage/README.md
@@ -1,6 +1,6 @@
 # garage
 
-![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.2.0](https://img.shields.io/badge/AppVersion-v2.2.0-informational?style=flat-square)
+![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.3.0](https://img.shields.io/badge/AppVersion-v2.3.0-informational?style=flat-square)
 
 S3-compatible object store for small self-hosted geo-distributed deployments.
 
@@ -147,6 +147,7 @@ S3-compatible object store for small self-hosted geo-distributed deployments.
 | webui.auth.enabled | bool | `false` | Enable authentication for WebUI |
 | webui.auth.existingSecret | string | `""` | Use an existing secret for authentication (must contain 'webuiAuthUserPass' key) |
 | webui.auth.userPassHash | string | `""` | When the chart manages the auth secret, provide this together with garage.secret.rpcSecret and garage.secret.adminToken. Generate with: htpasswd -nbBC 10 "username" "password" Example: "admin:$2y$10$DSTi9o..." |
+| webui.basePath | string | `"/"` | Base path or prefix for Web UI |
 | webui.enabled | bool | `false` | Enable the garage-webui deployment |
 | webui.extraVolumeMounts | object | `{}` | extra volume mounts for WebUI |
 | webui.extraVolumes | object | `{}` | extra volumes for WebUI |

--- a/garage/templates/job-configure.yaml
+++ b/garage/templates/job-configure.yaml
@@ -2,15 +2,20 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ include "garage.fullname" . }}-configure
+  name: {{ include "garage.fullname" . }}-configure{{- if not .Values.clusterConfig.helmSync.asHook }}-{{ .Release.Revision }}{{- end }}
   labels:
     {{- include "garage.labels" . | nindent 4 }}
   annotations:
+    {{- if .Values.clusterConfig.helmSync.asHook }}
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    {{- end }}
     "argocd.argoproj.io/hook": Sync
     "argocd.argoproj.io/hook-delete-policy": BeforeHookCreation,HookSucceeded
 spec:
+  {{- if not .Values.clusterConfig.helmSync.asHook }}
+  ttlSecondsAfterFinished: {{ .Values.clusterConfig.helmSync.ttlSecondsAfterFinished | default 300 }}
+  {{- end }}
   template:
     metadata:
       labels:

--- a/garage/tests/job-configure_test.yaml
+++ b/garage/tests/job-configure_test.yaml
@@ -19,7 +19,7 @@ tests:
           value: RELEASE-NAME-garage-configure
 
   # Helm hook annotations
-  - it: should have helm hook annotations
+  - it: should have helm hook annotations when asHook is true (default)
     set:
       clusterConfig.enabled: true
     asserts:
@@ -30,10 +30,32 @@ tests:
           path: metadata.annotations["helm.sh/hook-delete-policy"]
           value: before-hook-creation,hook-succeeded
 
-  # ArgoCD hook annotations
-  - it: should have ArgoCD hook annotations
+  - it: should not have helm hook annotations when asHook is false
     set:
       clusterConfig.enabled: true
+      clusterConfig.helmSync.asHook: false
+    asserts:
+      - isNull:
+          path: metadata.annotations["helm.sh/hook"]
+      - isNull:
+          path: metadata.annotations["helm.sh/hook-delete-policy"]
+
+  # ArgoCD hook annotations
+  - it: should always have ArgoCD hook annotations
+    set:
+      clusterConfig.enabled: true
+    asserts:
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/hook"]
+          value: Sync
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/hook-delete-policy"]
+          value: BeforeHookCreation,HookSucceeded
+
+  - it: should have ArgoCD hook annotations even when asHook is false
+    set:
+      clusterConfig.enabled: true
+      clusterConfig.helmSync.asHook: false
     asserts:
       - equal:
           path: metadata.annotations["argocd.argoproj.io/hook"]
@@ -304,6 +326,50 @@ tests:
           path: metadata.labels
           content:
             team: platform
+
+  # helmSync tests
+  - it: should not set ttlSecondsAfterFinished when asHook is true (default)
+    set:
+      clusterConfig.enabled: true
+    asserts:
+      - isNull:
+          path: spec.ttlSecondsAfterFinished
+
+  - it: should set ttlSecondsAfterFinished with default value when asHook is false
+    set:
+      clusterConfig.enabled: true
+      clusterConfig.helmSync.asHook: false
+    asserts:
+      - equal:
+          path: spec.ttlSecondsAfterFinished
+          value: 300
+
+  - it: should set custom ttlSecondsAfterFinished when asHook is false
+    set:
+      clusterConfig.enabled: true
+      clusterConfig.helmSync.asHook: false
+      clusterConfig.helmSync.ttlSecondsAfterFinished: 600
+    asserts:
+      - equal:
+          path: spec.ttlSecondsAfterFinished
+          value: 600
+
+  - it: should append release revision to name when asHook is false
+    set:
+      clusterConfig.enabled: true
+      clusterConfig.helmSync.asHook: false
+    asserts:
+      - matchRegex:
+          path: metadata.name
+          pattern: "RELEASE-NAME-garage-configure-\\d+"
+
+  - it: should not append release revision to name when asHook is true (default)
+    set:
+      clusterConfig.enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-garage-configure
 
   # Name override tests
   - it: should use fullname override

--- a/garage/values.yaml
+++ b/garage/values.yaml
@@ -405,7 +405,7 @@ clusterConfig:
 
   # Change sync behaviour with helm (helm install or helm upgrade)
   helmSync:
-    # -- If true, the configure job runs as a post-install/post-upgrade hook (waits for all resources to be ready first). 
+    # -- If true, the configure job runs as a post-install/post-upgrade hook (waits for all resources to be ready first).
     # Set to false to run the job as a regular resource alongside other pods. Recommended when startup of other pods depends on readiness of the garage container.
     asHook: true
     # -- Time in seconds to keep the completed job before automatic cleanup (only applies when asHook is false)

--- a/garage/values.yaml
+++ b/garage/values.yaml
@@ -403,6 +403,14 @@ clusterConfig:
   # -- Pod annotations
   podAnnotations: {}
 
+  # Change sync behaviour with helm (helm install or helm upgrade)
+  helmSync:
+    # -- If true, the configure job runs as a post-install/post-upgrade hook (waits for all resources to be ready first). 
+    # Set to false to run the job as a regular resource alongside other pods. Recommended when startup of other pods depends on readiness of the garage container.
+    asHook: true
+    # -- Time in seconds to keep the completed job before automatic cleanup (only applies when asHook is false)
+    ttlSecondsAfterFinished: 300
+
   # -- Pod security context
   podSecurityContext:
     runAsUser: 1000


### PR DESCRIPTION
#### Please check if the PR fulfills these requirements
- [ x ] The branch naming convention follows our guidelines
- [ x ] Docs have been added / updated (for bug fixes / features)

#### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

It removes the hooks used for installing/updating with helm to replace them with a more explicit solution ("ttlSecondsAfterFinished" plus revision on the job-name). The intended behaviour is that the job does no longer wait for all other pods/resources of other subcharts/the main chart to finish installing/updating until configuring garage. This is desirable as other services might need to have a running garage instance to finish installing/updating (e.g. for running migrations on startup). There is no hook option other than pre-... and post-... available for helm syncing, so the only option is to simulate the "start together with the rest" via "no hook" and the time-to-live.

#### What is the current behavior? (You can also link to an open issue here)

Currently the job waits until all the other manifests have been installed/updated when using helm, before starting itself. With another container waiting to connect with garage before finishing this helm-process, two processes wait for each other in a circular dependency.

#### What is the new behavior (if this is a feature change)?

This sub-chart starts and initializes itself independent of the whole helm install/update lifecycle. This behaviour is configurable via flag as job-hooks are probably more stable and the intended solution for the majority of usages. The other processes can wait until garage is ready and then interact with it to finish their own init process. This PR solves the same issue as previously solved for argocd via PR 12 (https://github.com/datahub-local/garage-helm/pull/12).

#### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No, the behaviour does not change by default (see default flag clusterconfig.helmSync.asHook = true). Even with the flag set to false, the behaviour should only change in a time-relevant sense (earlier garage init). The init-process works just like with annotation as proven through an earlier change (https://github.com/datahub-local/garage-helm/pull/12 + https://github.com/datahub-local/garage-helm/pull/13)

#### Other information:

These changes solve the same issue that was previously merged via PR 12 (https://github.com/datahub-local/garage-helm/pull/12) and PR 13 (https://github.com/datahub-local/garage-helm/pull/13) but now for helm/fluxCD and not just ArgoCD. However, only the Part from PR 12 needs to be changed as well now, as PR 13 solves the other part of the problem for both syncing with argocd (PR 12) and helm (this PR).

<!-- By submitting this Pull Request, you agree to follow our [Code of Conduct](https://github.com/datahub-local/garage-helm/CONTRIBUTING.md) -->
