### PR TITLE
feat(garage): add clusterDomain value to override DNS suffix

### DIFF
--- a/garage/README.md
+++ b/garage/README.md
@@ -44,6 +44,7 @@ S3-compatible object store for small self-hosted geo-distributed deployments.
 | clusterConfig.securityContext | object | `{"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | Container security context |
 | clusterConfig.tolerations | list | `[]` | Tolerations |
 | clusterConfig.toolsImage.repository | string | `"busybox"` | Image to use for the tools task for the configuration job |
+| clusterDomain | string | `"cluster.local"` | Cluster DNS domain. Override on clusters not using the default `cluster.local` (e.g. kubelet `--cluster-domain=cluster.example.com`). |
 | commonLabels | object | `{}` | Additional labels to add to all resources created by this chart |
 | deployment.kind | string | `"StatefulSet"` | Switchable to DaemonSet |
 | deployment.podManagementPolicy | string | `"OrderedReady"` | If using statefulset, allow Parallel or OrderedReady (default) |

--- a/garage/templates/secret-configure.yaml
+++ b/garage/templates/secret-configure.yaml
@@ -13,7 +13,7 @@ stringData:
     # Default values
     DEFAULT_ZONE="{{ .Values.clusterConfig.layout.zone | default "dc1" }}"
     DEFAULT_CAPACITY="{{ .Values.clusterConfig.layout.capacity | default .Values.persistence.data.size | default "1T" }}"
-    SERVICE_DNS={{ include "garage.fullname" . }}-headless.{{ .Release.Namespace }}.svc.cluster.local
+    SERVICE_DNS={{ include "garage.fullname" . }}-headless.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}
 
     echo "Waiting for Garage cluster to be ready..."
     sleep 60

--- a/garage/templates/webui-deployment.yaml
+++ b/garage/templates/webui-deployment.yaml
@@ -36,9 +36,9 @@ spec:
           imagePullPolicy: {{ .Values.webui.image.pullPolicy }}
           env:
             - name: API_BASE_URL
-              value: "http://{{ include "garage.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.ports.admin }}"
+              value: "http://{{ include "garage.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.service.ports.admin }}"
             - name: S3_ENDPOINT_URL
-              value: "http://{{ include "garage.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.ports.s3Api }}"
+              value: "http://{{ include "garage.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.service.ports.s3Api }}"
             - name: API_ADMIN_KEY
               valueFrom:
                 secretKeyRef:

--- a/garage/tests/secret-configure_test.yaml
+++ b/garage/tests/secret-configure_test.yaml
@@ -24,6 +24,27 @@ tests:
       - exists:
           path: stringData["configure.sh"]
 
+  - it: should use default cluster.local DNS suffix
+    set:
+      clusterConfig.enabled: true
+    release:
+      namespace: test-ns
+    asserts:
+      - matchRegex:
+          path: stringData["configure.sh"]
+          pattern: "SERVICE_DNS=RELEASE-NAME-garage-headless\\.test-ns\\.svc\\.cluster\\.local"
+
+  - it: should honor clusterDomain override in SERVICE_DNS
+    set:
+      clusterConfig.enabled: true
+      clusterDomain: cluster.example.com
+    release:
+      namespace: test-ns
+    asserts:
+      - matchRegex:
+          path: stringData["configure.sh"]
+          pattern: "SERVICE_DNS=RELEASE-NAME-garage-headless\\.test-ns\\.svc\\.cluster\\.example\\.com"
+
   # Bucket permissions - string format
   - it: string bucket format should grant read and write
     set:

--- a/garage/tests/webui-deployment_test.yaml
+++ b/garage/tests/webui-deployment_test.yaml
@@ -146,6 +146,26 @@ tests:
             name: S3_ENDPOINT_URL
             value: "http://RELEASE-NAME-garage.test-ns.svc.cluster.local:3900"
 
+  - it: should honor clusterDomain override in service URLs
+    set:
+      webui.enabled: true
+      clusterDomain: cluster.example.com
+      service.ports.admin: 3903
+      service.ports.s3Api: 3900
+    release:
+      namespace: test-ns
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: API_BASE_URL
+            value: "http://RELEASE-NAME-garage.test-ns.svc.cluster.example.com:3903"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: S3_ENDPOINT_URL
+            value: "http://RELEASE-NAME-garage.test-ns.svc.cluster.example.com:3900"
+
   - it: should set API_ADMIN_KEY from secret
     set:
       webui.enabled: true

--- a/garage/values.yaml
+++ b/garage/values.yaml
@@ -7,6 +7,10 @@ commonLabels: {}
 #   app.kubernetes.io/part-of: storage
 #   team: platform
 
+# -- Cluster DNS domain. Override on clusters not using the default
+# `cluster.local` (e.g. kubelet `--cluster-domain=cluster.example.com`).
+clusterDomain: cluster.local
+
 # Garage configuration. These values go to garage.toml
 garage:
   # -- Can be changed for better performance on certain systems


### PR DESCRIPTION
## Problem

The chart hardcodes `svc.cluster.local` in three places, with no override hook:

- `templates/secret-configure.yaml` — `SERVICE_DNS` used by the configure Job to resolve `garage-0/1/2.{headless}` for layout/bucket/key setup.
- `templates/webui-deployment.yaml` — `API_BASE_URL` / `S3_ENDPOINT_URL` env vars.

On clusters where the cluster DNS domain is not the default `cluster.local` (kubelet `--cluster-domain` + matching CoreDNS zone), every workload reaching these hostnames gets `NXDOMAIN`:

- Configure Job hangs forever on the first DNS resolve, only logging `Waiting for Garage cluster to be ready...`.
- WebUI pod can't reach the admin/S3 API.

## Fix

Introduce a top-level `clusterDomain` value (community convention, cf. cert-manager, external-dns, kube-prometheus-stack) defaulting to `cluster.local`, and wire it into the three hardcoded sites. The default keeps existing users unaffected.

## Changes

- `values.yaml`: new `clusterDomain: cluster.local`
- `templates/secret-configure.yaml`: `SERVICE_DNS` suffix uses `.Values.clusterDomain`
- `templates/webui-deployment.yaml`: `API_BASE_URL` / `S3_ENDPOINT_URL` use `.Values.clusterDomain`
- `README.md`: documented the new value
- Unit tests for both the default and the override

## Verification

- `helm unittest garage` — 338 tests pass (18 suites), including new default + override cases
- `helm lint garage` passes
- `helm template` confirms default renders `cluster.local` and `--set clusterDomain=cluster.example.com` propagates to all sites

Fixes #34