### PR TITLE
fix(garage): apply securityContext to clusterConfig init containers

### DIFF
--- a/garage/templates/job-configure.yaml
+++ b/garage/templates/job-configure.yaml
@@ -37,6 +37,8 @@ spec:
         - name: get-busybox-tools
           image: "{{ .Values.clusterConfig.toolsImage.repository }}:{{ .Values.clusterConfig.toolsImage.tag }}"
           imagePullPolicy: {{ .Values.clusterConfig.toolsImage.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.clusterConfig.securityContext | nindent 12 }}
           resources:
             requests:
               cpu: 50m
@@ -51,6 +53,8 @@ spec:
         - name: get-garage-bin
           image: "{{ .Values.clusterConfig.image.repository | default .Values.image.repository }}:{{ .Values.clusterConfig.image.tag | default .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.clusterConfig.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.clusterConfig.securityContext | nindent 12 }}
           resources:
             requests:
               cpu: 50m

--- a/garage/tests/job-configure_test.yaml
+++ b/garage/tests/job-configure_test.yaml
@@ -147,6 +147,39 @@ tests:
           path: spec.template.spec.initContainers[1].image
           value: "custom/garage:v1.0.0"
 
+  - it: should set security context on init containers
+    set:
+      clusterConfig.enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.capabilities.drop[0]
+          value: ALL
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.readOnlyRootFilesystem
+          value: true
+      - equal:
+          path: spec.template.spec.initContainers[1].securityContext.capabilities.drop[0]
+          value: ALL
+      - equal:
+          path: spec.template.spec.initContainers[1].securityContext.readOnlyRootFilesystem
+          value: true
+
+  - it: should honor custom securityContext on init containers
+    set:
+      clusterConfig.enabled: true
+      clusterConfig.securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.allowPrivilegeEscalation
+          value: false
+      - equal:
+          path: spec.template.spec.initContainers[1].securityContext.allowPrivilegeEscalation
+          value: false
+
   # Main container tests
   - it: should use busybox image for configure container
     set:


### PR DESCRIPTION
## Problem

The `clusterConfig` Job (`templates/job-configure.yaml`) wires `clusterConfig.securityContext` only into the main `configure` container. The two init containers — `get-busybox-tools` and `get-garage-bin` — have no `securityContext` block, so they fall through to apiserver defaults (privilege escalation allowed, no capability drops).

On clusters that warn or enforce the Pod Security Standards `restricted` profile, this trips:

```
Warning: would violate PodSecurity "restricted:latest":
  allowPrivilegeEscalation != false (containers "get-busybox-tools", "get-garage-bin"
    must set securityContext.allowPrivilegeEscalation=false),
  unrestricted capabilities (containers "get-busybox-tools", "get-garage-bin"
    must set securityContext.capabilities.drop=["ALL"])
```

Under `warn`-level policy the Job still runs, but enforcement-level `restricted` blocks it outright.

## Fix

Apply the existing `clusterConfig.securityContext` to both init containers, matching the main `configure` container. Reusing the same value keeps the API surface small; splitting into a dedicated `initContainerSecurityContext` can come later if a use case needs it.

## Changes

- `templates/job-configure.yaml`: add `securityContext` to `get-busybox-tools` and `get-garage-bin`
- Unit tests for the default drops and a custom override

## Verification

- `helm unittest garage` — 337 tests pass (18 suites), including new init-container securityContext cases
- `helm lint garage` passes
- `helm template` confirms both init containers now render `securityContext`

Fixes #33
