### PR TITLE
fix: crashing get-garage-bin container

### DIFF
--- a/garage/templates/job-configure.yaml
+++ b/garage/templates/job-configure.yaml
@@ -58,10 +58,10 @@ spec:
           resources:
             requests:
               cpu: 50m
-              memory: 50Mi
+              memory: 100Mi
             limits:
               cpu: 50m
-              memory: 50Mi
+              memory: 100Mi
           command: ["/tools/busybox", "sh", "-c", "/tools/busybox cp /garage /shared/garage"]
           volumeMounts:
             - name: tools


### PR DESCRIPTION
#### Please check if the PR fulfills these requirements
- [x] The branch naming convention follows our guidelines
- [x] Docs have been added / updated (for bug fixes / features)

#### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

Bug fix

#### What is the current behavior? (You can also link to an open issue here)
I got an error attempting to deploy garage with clusterConfig enabled because of insufficient memory of get-garage-bin container. Details listed below.

#### What is the new behavior (if this is a feature change)?

Everything works fine after increasing it from 50Mi to 100Mi

#### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No breaking changes

#### Other information:

❯ ls -lh ../Cellar/garage/2.3.0/bin/garage
-r-xr-xr-x@ 1 yaroslove admin 46M Apr 16 19:34 ../Cellar/garage/2.3.0/bin/garage

my local version of garage binary takes 46M

part of kubectl describe garage-init pod:
get-garage-bin:
Container ID: containerd://83cc669b08b462c37669d93efde33151fe9d812a620b9371e10be2d3f32b8823
Image: dxflrs/garage:v2.3.0
Image ID: docker.io/dxflrs/amd64_garage@sha256:dac0c92add4f1a0b41035e94b41036a270ffbe88a37c7ac9c3f19e6dc5bdccf2
Port:
Host Port:
Command:
/tools/busybox
sh
-c
/tools/busybox cp /garage /shared/garage
State: Waiting
Reason: CrashLoopBackOff
Last State: Terminated
Reason: OOMKilled
Exit Code: 137
Started: Mon, 06 Jul 2026 03:27:25 +0300
Finished: Mon, 06 Jul 2026 03:27:26 +0300
Ready: False
Restart Count: 4
Limits:
cpu: 50m
memory: 50Mi
Requests:
cpu: 50m
memory: 50Mi

<!-- By submitting this Pull Request, you agree to follow our [Code of Conduct](https://github.com/datahub-local/garage-helm/CONTRIBUTING.md) -->
